### PR TITLE
Do not run build when feature branch is updated

### DIFF
--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'development'
-      - 'feature/*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
       - 'development'
+  pull_request:
+    branches:
+      - '*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Pushing anything to an in development feature branch triggers the build pipeline to run, which does not make sense. Feature branches are in development features that are most likely unstable or not building at all.